### PR TITLE
Bump to stable version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0
+
+* Bumped to stable release.
+
 ## [1.0.0-dev] - 2021-02-23
 
 * Updated to support null-safety

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,5 +14,3 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-
-flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,11 @@
 name: holding_gesture
 description: A customized GestureDetector that acts on holding a determined Widget.
-version: 1.0.0-dev
+version: 1.0.0
 homepage: https://github.com/gildaswise/holding_gesture
 
 environment:
-  sdk: '>=2.12.0-259.8.beta <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
+  flutter: '>=2.0.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
Now that null safety is stable, packages should publish stable versions.

This also prevents publishing warnings on Pub (see https://github.com/simpleclub/math_keyboard/runs/2117873696#step:6:213).

For more information, see https://github.com/fkleon/math-expressions/issues/46.